### PR TITLE
Enable multicolour prompt prefixes

### DIFF
--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -94,11 +94,11 @@ var suggestions = []prompt.Suggest{
 }
 
 func livePrefix(defaultPrefix string) prompt.PrefixCallback {
-	return func() string {
+	return func() prompt.Prefix {
 		if ctx.url.Path == "/" {
-			return defaultPrefix
+			return prompt.Prefix{Text: defaultPrefix}
 		}
-		return ctx.url.String() + "> "
+		return prompt.Prefix{Text: ctx.url.String() + "> "}
 	}
 }
 

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -32,8 +32,8 @@ func completer(in prompt.Document) ([]prompt.Suggest, istrings.RuneNumber, istri
 	return prompt.FilterHasPrefix(s, w, true), startIndex, endIndex
 }
 
-func changeLivePrefix() string {
-	return LivePrefix
+func changeLivePrefix() prompt.Prefix {
+	return prompt.Prefix{Text: LivePrefix}
 }
 
 func main() {

--- a/constructor.go
+++ b/constructor.go
@@ -7,7 +7,16 @@ import "fmt"
 type Option func(prompt *Prompt) error
 
 // Callback function that returns a prompt prefix.
-type PrefixCallback func() (prefix string)
+// Prefix represents the text shown before the user input
+// along with information about whether the text contains
+// custom ANSI colour sequences.
+type Prefix struct {
+	Text        string
+	CustomColor bool
+}
+
+// PrefixCallback returns a prompt prefix.
+type PrefixCallback func() Prefix
 
 const DefaultIndentSize = 2
 
@@ -74,7 +83,9 @@ func WithTitle(t string) Option {
 // WithPrefix can be used to set a prefix string for the prompt.
 func WithPrefix(prefix string) Option {
 	return func(p *Prompt) error {
-		p.renderer.prefixCallback = func() string { return prefix }
+		p.renderer.prefixCallback = func() Prefix {
+			return Prefix{Text: prefix}
+		}
 		return nil
 	}
 }
@@ -321,8 +332,8 @@ func DefaultExecuteOnEnterCallback(p *Prompt, indentSize int) (int, bool) {
 	return 0, true
 }
 
-func DefaultPrefixCallback() string {
-	return "> "
+func DefaultPrefixCallback() Prefix {
+	return Prefix{Text: "> ", CustomColor: false}
 }
 
 // New returns a Prompt with powerful auto-completion.

--- a/renderer.go
+++ b/renderer.go
@@ -73,12 +73,14 @@ func (r *Renderer) Setup() {
 	}
 }
 
-func (r *Renderer) renderPrefix(prefix string) {
-	r.out.SetColor(r.prefixTextColor, r.prefixBGColor, false)
+func (r *Renderer) renderPrefix(prefix Prefix) {
+	if !prefix.CustomColor {
+		r.out.SetColor(r.prefixTextColor, r.prefixBGColor, false)
+	}
 	if _, err := r.out.WriteString("\r"); err != nil {
 		panic(err)
 	}
-	if _, err := r.out.WriteString(prefix); err != nil {
+	if _, err := r.out.WriteString(prefix.Text); err != nil {
 		panic(err)
 	}
 	r.out.SetColor(DefaultColor, DefaultColor, false)
@@ -112,10 +114,14 @@ func (r *Renderer) renderCompletion(buf *Buffer, completions *CompletionManager)
 		return
 	}
 	prefix := r.prefixCallback()
-	prefixWidth := istrings.GetWidth(prefix)
+	plain := prefix.Text
+	if prefix.CustomColor {
+		plain = istrings.StripANSI(prefix.Text)
+	}
+	prefixWidth := istrings.GetWidth(plain)
 	formatted, width := formatSuggestions(
 		suggestions,
-		r.col-istrings.GetWidth(prefix)-1, // -1 means a width of scrollbar
+		r.col-istrings.GetWidth(plain)-1, // -1 means a width of scrollbar
 	)
 	// +1 means a width of scrollbar.
 	width++
@@ -205,7 +211,11 @@ func (r *Renderer) Render(buffer *Buffer, completion *CompletionManager, lexer L
 
 	text := buffer.Text()
 	prefix := r.prefixCallback()
-	prefixWidth := istrings.GetWidth(prefix)
+	plain := prefix.Text
+	if prefix.CustomColor {
+		plain = istrings.StripANSI(prefix.Text)
+	}
+	prefixWidth := istrings.GetWidth(plain)
 	col := r.col - prefixWidth
 	endLine := buffer.startLine + int(r.row) - 1
 	cursor := positionAtEndOfStringLine(text, col, endLine)
@@ -235,9 +245,18 @@ func (r *Renderer) renderText(lexer Lexer, input string, startLine int) {
 	}
 
 	prefix := r.prefixCallback()
-	prefixWidth := istrings.GetWidth(prefix)
+	plainPrefix := prefix.Text
+	if prefix.CustomColor {
+		plainPrefix = istrings.StripANSI(prefix.Text)
+	}
+	prefixWidth := istrings.GetWidth(plainPrefix)
 	col := r.col - prefixWidth
-	multilinePrefix := r.getMultilinePrefix(prefix)
+	var multilinePrefix Prefix
+	if prefix.CustomColor {
+		multilinePrefix = prefix
+	} else {
+		multilinePrefix = Prefix{Text: r.getMultilinePrefix(plainPrefix)}
+	}
 	if startLine != 0 {
 		prefix = multilinePrefix
 	}
@@ -285,7 +304,7 @@ func (r *Renderer) flush() {
 	debug.AssertNoError(r.out.Flush())
 }
 
-func (r *Renderer) renderLine(prefix, line string, color Color) {
+func (r *Renderer) renderLine(prefix Prefix, line string, color Color) {
 	r.renderPrefix(prefix)
 	r.writeStringColor(line, color)
 }
@@ -339,9 +358,18 @@ func (r *Renderer) getMultilinePrefix(prefix string) string {
 // and writes the result
 func (r *Renderer) lex(lexer Lexer, input string, startLine int) {
 	prefix := r.prefixCallback()
-	prefixWidth := istrings.GetWidth(prefix)
+	plainPrefix := prefix.Text
+	if prefix.CustomColor {
+		plainPrefix = istrings.StripANSI(prefix.Text)
+	}
+	prefixWidth := istrings.GetWidth(plainPrefix)
 	col := r.col - prefixWidth
-	multilinePrefix := r.getMultilinePrefix(prefix)
+	var multilinePrefix Prefix
+	if prefix.CustomColor {
+		multilinePrefix = prefix
+	} else {
+		multilinePrefix = Prefix{Text: r.getMultilinePrefix(plainPrefix)}
+	}
 	var lineCharIndex istrings.Width
 	var lineNumber int
 	endLine := startLine + int(r.row)
@@ -457,7 +485,11 @@ func (r *Renderer) resetFormatting() {
 func (r *Renderer) BreakLine(buffer *Buffer, lexer Lexer) {
 	// Erasing and Renderer
 	prefix := r.prefixCallback()
-	prefixWidth := istrings.GetWidth(prefix)
+	plainPrefix := prefix.Text
+	if prefix.CustomColor {
+		plainPrefix = istrings.StripANSI(prefix.Text)
+	}
+	prefixWidth := istrings.GetWidth(plainPrefix)
 	cursor := positionAtEndOfString(buffer.Document().TextBeforeCursor(), r.col-prefixWidth)
 	cursor.X += prefixWidth
 	r.clear(cursor)
@@ -480,7 +512,12 @@ func (r *Renderer) BreakLine(buffer *Buffer, lexer Lexer) {
 // Get the number of columns that are available
 // for user input.
 func (r *Renderer) UserInputColumns() istrings.Width {
-	return r.col - istrings.GetWidth(r.prefixCallback())
+	prefix := r.prefixCallback()
+	plain := prefix.Text
+	if prefix.CustomColor {
+		plain = istrings.StripANSI(prefix.Text)
+	}
+	return r.col - istrings.GetWidth(plain)
 }
 
 // clear erases the screen from a beginning of input

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -3,6 +3,8 @@ package strings
 import (
 	"unicode/utf8"
 
+	"regexp"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
@@ -27,6 +29,18 @@ func RuneCount(b []byte) RuneNumber {
 // cluster's width, and adds them up to a total.
 func GetWidth(text string) Width {
 	return Width(uniseg.StringWidth(text))
+}
+
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+// StripANSI removes ANSI escape sequences from the given text.
+func StripANSI(text string) string {
+	return ansiRegexp.ReplaceAllString(text, "")
+}
+
+// GetWidthNoANSI calculates the width of the text ignoring any ANSI escape sequences.
+func GetWidthNoANSI(text string) Width {
+	return GetWidth(StripANSI(text))
 }
 
 // Returns the number of horizontal cells needed to print the given

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -37,6 +37,21 @@ func TestGetWidth(t *testing.T) {
 	}
 }
 
+func TestStripANSI(t *testing.T) {
+	in := "\x1b[31mfoo\x1b[0m"
+	want := "foo"
+	if got := strings.StripANSI(in); got != want {
+		t.Errorf("Should be %#v, but got %#v", want, got)
+	}
+}
+
+func TestGetWidthNoANSI(t *testing.T) {
+	in := "\x1b[31mfoo\x1b[0m"
+	if got := strings.GetWidthNoANSI(in); got != 3 {
+		t.Errorf("Width should be 3, got %#v", got)
+	}
+}
+
 func TestRuneIndexNthColumn(t *testing.T) {
 	tests := []struct {
 		text string


### PR DESCRIPTION
## Summary
- allow PrefixCallback to return a struct containing text and colour info
- support custom coloured prefixes in renderer
- add functions for stripping ANSI codes and calculating width without them
- update examples to new API
- add tests for ANSI stripping

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68513c84f9dc8328a2a3795f100552fe